### PR TITLE
Replace plugin version 3.0 by 3.0.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="com.appsflyer.phonegap.plugins.appsflyer"
-        version="3.0">
+        version="3.0.0">
     <name>AppsFlyer</name>
     <description>Cordova AppsFlyer Plugin</description>
     <license>Apache 2.0</license>


### PR DESCRIPTION
To fix the build error @ Monaca when the user upload this plugin as zip file.
Because 3.0 is not correct version format. 